### PR TITLE
Support O2mania 1.2-style BMS

### DIFF
--- a/src/org/open2jam/parser/BMSChart.java
+++ b/src/org/open2jam/parser/BMSChart.java
@@ -12,6 +12,7 @@ import javax.imageio.ImageIO;
 public class BMSChart extends Chart
 {
     int lntype;
+    boolean o2mania_style;
 
     File source;
     int lnobj;


### PR DESCRIPTION
In O2mania 1.2, the arrangement of keys are different from Open2Jam: They use SC (16), 1 (11), 2 (12), 3 (13), 4 (14), 5 (15), 6 (18) to S, D, F, [Space], J, K, L respectively.

This change makes Open2jam support O2mania 1.2-styled BMS, which are the formats of some BMS files distributed through o2mania.com. It adds a new field to the `BMSChart`: `o2mania_style`.

`o2mania_style` will be true if the SC channel is used at least once, and all channels after 18 are not used at all. When it is true, the parser will read the according to its style.
