### PR TITLE
Judge missed notes by time.

### DIFF
--- a/src/org/open2jam/render/DistanceRender.java
+++ b/src/org/open2jam/render/DistanceRender.java
@@ -57,7 +57,7 @@ public class DistanceRender extends Render
     }
 
     @Override
-    void check_judgment(NoteEntity ne)
+    void check_judgment(NoteEntity ne, double now)
     {
         JUDGE judge;
         switch (ne.getState())

--- a/src/org/open2jam/render/Render.java
+++ b/src/org/open2jam/render/Render.java
@@ -492,7 +492,7 @@ public abstract class Render implements GameWindowCallback
                     if(e instanceof MeasureEntity) y -= 1;
                     e.setPos(e.getX(), y);
 
-                    if(e instanceof NoteEntity) check_judgment((NoteEntity)e);
+                    if(e instanceof NoteEntity) check_judgment((NoteEntity)e, now);
                 }
 
                 if(e.isDead())j.remove();
@@ -576,7 +576,7 @@ public abstract class Render implements GameWindowCallback
 
     abstract void check_keyboard(double now);
 
-    abstract void check_judgment(NoteEntity noteEntity);
+    abstract void check_judgment(NoteEntity noteEntity, double now);
 
     /* play a sample */
     public void queueSample(Event.SoundSample sample)

--- a/src/org/open2jam/render/TimeRender.java
+++ b/src/org/open2jam/render/TimeRender.java
@@ -6,6 +6,8 @@ import org.lwjgl.opengl.DisplayMode;
 import org.open2jam.GameOptions;
 
 import org.open2jam.util.SystemTimer;
+import java.util.logging.Level;
+import org.open2jam.util.Logger;
 
 import org.open2jam.parser.Chart;
 import org.open2jam.parser.Event;
@@ -56,14 +58,13 @@ public class TimeRender extends Render
     }
 
     @Override
-    void check_judgment(NoteEntity ne)
+    void check_judgment(NoteEntity ne, double now)
     {
         JUDGE judge;
         switch (ne.getState())
         {
             case NOT_JUDGED: // you missed it (no keyboard input)
-                if((ne instanceof LongNoteEntity && ne.getStartY() >= judgmentArea()) //needed by the ln head
-                        || (ne.getY() >= judgmentArea())) // TODO: compare the time, not the position
+                if(now > ne.getTime() + JUDGE.BAD.value)
                 {
                     if(judgment_entity != null)judgment_entity.setDead(true);
                     judgment_entity = skin.getEntityMap().get("EFFECT_"+JUDGE.MISS.toString()).copy();
@@ -142,7 +143,9 @@ public class TimeRender extends Render
             break;
             case LN_HOLD:    // You keept too much time the note held that it misses
                 if(ne.getY() >= judgmentArea()) // TODO: use the time
+                //if(now > ((LongNoteEntity)ne).getEndTime() + JUDGE.BAD.value) // somehow getEndTime just return -1.
                 {
+				//Logger.global.log(Level.INFO,String.format("FUCK! %.3f %.3f %d", now, ((LongNoteEntity)ne).getEndTime(), JUDGE.BAD.value));
                     if(judgment_entity != null)judgment_entity.setDead(true);
                     judgment_entity = skin.getEntityMap().get("EFFECT_"+JUDGE.MISS.toString()).copy();
                     entities_matrix.add(judgment_entity);


### PR DESCRIPTION
This patch makes open2jam judge misses by time, instead of by distance, in TimeRender.

Without it, there are areas that are below the judging area by time (> BAD) but not yet counted as miss, because misses are measured by distance. The notes in that area can't be played at all, and prevent the next note from being played, until all there are no more notes in that area. This patch fixes it.
