### PR TITLE
Use XML to store game options instead

### DIFF
--- a/src/org/open2jam/Config.java
+++ b/src/org/open2jam/Config.java
@@ -1,9 +1,19 @@
 package org.open2jam;
 
+import java.beans.XMLDecoder;
+import java.beans.XMLEncoder;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.lwjgl.input.Keyboard;
 import org.open2jam.parsers.ChartList;
 import org.open2jam.parsers.Event;
@@ -20,6 +30,30 @@ public abstract class Config
     
     private static VoileMap<String, Serializable> VMap;
     private static GameOptions options;
+            
+    public static final String OPTIONS_FILE = "game-options.xml";
+
+    private static GameOptions loadGameOptions() {
+        try {
+            XMLDecoder decoder = new XMLDecoder(new BufferedInputStream(new FileInputStream(OPTIONS_FILE)));
+            Object result = decoder.readObject();
+            decoder.close();
+            if (result instanceof GameOptions) return (GameOptions)result;
+        } catch (IOException ex) {
+            Logger.getLogger(Config.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        return null;
+    }
+    
+    public static void saveGameOptions() {
+        try {
+            XMLEncoder encoder = new XMLEncoder(new BufferedOutputStream(new FileOutputStream(OPTIONS_FILE)));
+            encoder.writeObject(options);
+            encoder.close();
+        } catch (IOException ex) {
+            Logger.getLogger(GameOptions.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
 
     public enum KeyboardType {K4, K5, K6, K7, K8, /*K9*/}
     
@@ -34,7 +68,11 @@ public abstract class Config
     
     public static void openDB() {
         
-        options = new GameOptions();
+        options = loadGameOptions();
+        
+        if (options == null) {
+            options = new GameOptions();
+        }
         
         if(!CONFIG_FILE.exists()) { // create now
             
@@ -108,6 +146,7 @@ public abstract class Config
         } else {           
             VMap = new VoileMap<String, Serializable>(CONFIG_FILE);
         }
+        
     }
 
     @SuppressWarnings("unchecked")
@@ -146,7 +185,8 @@ public abstract class Config
     }
     
     public static void setGameOptions(GameOptions go) {
-        options.save();
+        options = go;
+        saveGameOptions();
     }
     
     public static GameOptions getGameOptions() {

--- a/src/org/open2jam/GameOptions.java
+++ b/src/org/open2jam/GameOptions.java
@@ -1,7 +1,10 @@
 package org.open2jam;
 
+import java.beans.XMLEncoder;
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -19,165 +22,6 @@ import org.open2jam.parsers.Event;
  */
 public class GameOptions {
     
-    private static final File OPTIONS_FILE = new File("game_options.properties");
-    
-    public static final Properties DEFAULT_PROPERTIES = new Properties();
-    
-    interface PropertyBinding {
-        public void load(GameOptions options, String value);
-        public String save(GameOptions options);
-    }
-    
-    static class Binding implements PropertyBinding {
-        
-        final String fieldName;
-        
-        public Binding(String fieldName) {
-            this.fieldName = fieldName;
-        }
-        
-        @Override
-        public void load(GameOptions options, String value) {
-            try {
-                GameOptions.class.getDeclaredField(fieldName).set(options, parse(value));
-            } catch (Exception ex) {
-                throw new RuntimeException(ex);
-            }
-        }
-        
-        public Object parse(String value) { return value; }
-        public String stringify(Object value) { return value.toString(); }
-
-        @Override
-        public String save(GameOptions opts) {
-            try {
-                return stringify(GameOptions.class.getDeclaredField(fieldName).get(opts));
-            } catch (Exception ex) {
-                throw new RuntimeException(ex);
-            }
-        }
-        
-    }
-    
-    static class DoubleBinding extends Binding {
-        public DoubleBinding(String fieldName) { super(fieldName); }
-        @Override
-        public Object parse(String value) { return Double.parseDouble(value); }
-    }
-    static class FloatBinding extends Binding {
-        public FloatBinding(String fieldName) { super(fieldName); }
-        @Override
-        public Object parse(String value) { return Float.parseFloat(value); }
-    }
-    static class BooleanBinding extends Binding {
-        public BooleanBinding(String fieldName) { super(fieldName); }
-        @Override
-        public Object parse(String value) { return Boolean.parseBoolean(value); }
-    }
-    static class IntegerBinding extends Binding {
-        public IntegerBinding(String fieldName) { super(fieldName); }
-        @Override
-        public Object parse(String value) { return Integer.parseInt(value); }
-    }
-    
-    static class EnumBinding extends Binding {
-        
-        public Class enumClass;
-        
-        public EnumBinding(Class enumClass, String fieldName) {
-            super(fieldName);
-            this.enumClass = enumClass;
-        }
-
-        @Override
-        public Object parse(String value) {
-            for (Object o : enumClass.getEnumConstants()) {
-                if (((Enum)o).name().equals(value)) return o;
-            }
-            return null;
-        }
-
-        @Override
-        public String stringify(Object value) {
-            return ((Enum)value).name();
-        }
-        
-    }
-    
-    static enum Property {
-        speedMultiplier("mods.speed.multiplier", "1.0", new DoubleBinding("hispeed")),
-        speedType("mods.speed.type", "HiSpeed", new EnumBinding(SpeedType.class, "speed_type")),
-        visibility("mods.visibility", "None", new EnumBinding(VisibilityMod.class, "visibilityModifier")),
-        channel("mods.channel", "None", new EnumBinding(ChannelMod.class, "channelModifier")),
-        keyVolume("volume.key", "1.0", new FloatBinding("keyVolume")),
-        bgmVolume("volume.bgm", "1.0", new FloatBinding("BGMVolume")),
-        masterVolume("volume.master", "1.0", new FloatBinding("masterVolume")),
-        autoplayEnabled("autoplay.enabled", "false", new BooleanBinding("autoplay")),
-        autoplayChannels("autoplay.channels", "", new Binding("autoplay_channels") {
-
-            @Override
-            public Object parse(String value) {
-                ArrayList<Boolean> out = new ArrayList<Boolean>();
-                if (value.isEmpty()) {
-                    for(Event.Channel c : Event.Channel.values())
-                    {
-                        if(c.toString().startsWith("NOTE_"))
-                            out.add(c.isAutoplay());
-                    }
-                } else for (String s : value.split(",")) {
-                    out.add(Boolean.parseBoolean(s));
-                }
-                return out;
-            }
-
-            @Override
-            public String stringify(Object value) {
-                StringBuilder builder = new StringBuilder();
-                for (boolean c : (ArrayList<Boolean>)value) {
-                    if (builder.length() > 0) builder.append(",");
-                    builder.append(Boolean.toString(c));
-                }
-                return builder.toString();
-            }
-            
-        }),
-        autosoundEnabled("autosound.enabled", "false", new BooleanBinding("autosound")),
-        fullScreen("display.full_screen", "false", new BooleanBinding("fullscreen")),
-        bilinear("display.bilinear", "true", new BooleanBinding("bilinear")),
-        vsync("display.vsync", "true", new BooleanBinding("vsync")),
-        width("display.width", "0", new IntegerBinding("width")),
-        height("display.height", "0", new IntegerBinding("height")),
-        bpp("display.bpp", "0", new IntegerBinding("bpp")),
-        freq("display.freq", "0", new IntegerBinding("freq")),
-        vlcPath("vlc.library_path", "", new Binding("vlc")),
-        displayLag("latency.display", "0.0", new DoubleBinding("displayLag")),
-        audioLatency("latency.audio", "0.0", new DoubleBinding("audioLatency"));
-        
-        final String name;
-        final String defaultValue;
-        final PropertyBinding binding;
-
-        private Property(String name, String defaultValue, PropertyBinding binding) {
-            this.name = name;
-            this.defaultValue = defaultValue;
-            this.binding = binding;
-        }
-        
-        public void load(Properties props, GameOptions opts) {
-            binding.load(opts, props.getProperty(name));
-        }
-        
-        public void save(Properties props, GameOptions opts) {
-            props.setProperty(name, binding.save(opts));
-        }
-        
-    }
-    
-    static {
-        for (Property property : Property.values()) {
-            DEFAULT_PROPERTIES.setProperty(property.name, property.defaultValue);
-        }
-    }
     
     /*
      * "Hi-Speed"=>0, "xR-Speed"=>1, "W-Speed"=>2
@@ -206,55 +50,50 @@ public class GameOptions {
     }
     
     // fields
-    double hispeed;
-    SpeedType speed_type;
-    VisibilityMod visibilityModifier;
-    ChannelMod channelModifier;
+    private double speedMultiplier = 1.0;
+    private SpeedType speedType = SpeedType.HiSpeed;
+    private VisibilityMod visibilityModifier = VisibilityMod.None;
+    private ChannelMod channelModifier = ChannelMod.None;
     
-    float keyVolume, BGMVolume, masterVolume;
+    float keyVolume = 1.0f;
+    float bgmVolume = 1.0f;
+    float masterVolume = 1.0f;
     
-    boolean autoplay;
-    ArrayList<Boolean> autoplay_channels;
-    boolean autosound;
+    private boolean autoplay = false;
+    private ArrayList<Boolean> autoplayChannels = generateDefaultAutoplayChannels();
+    private boolean autosound = false;
 
     // display options
-    boolean fullscreen, bilinear, vsync;
-    int width,height,bpp,freq;
+    private boolean displayFullscreen = false;
+    private boolean displayBilinear = true;
+    private boolean displayVsync = true;
+    private int displayWidth = 0;
+    private int displayHeight = 0;
+    private int displayBitsPerPixel = 0;
+    private int displayFrequency = 0;
     
     // VLC lib path
-    String vlc = "";
-    double displayLag = 0;
-    double audioLatency = 0;
+    private String vlc = "";
+    
+    // display lag and audio latency
+    private double displayLag = 0;
+    private double audioLatency = 0;
     
     //public constructor. give default options
     public GameOptions() {
-        load();
     }
     
-    public void load() {
-        Properties properties = new Properties(DEFAULT_PROPERTIES);
-        try {
-            properties.load(new FileInputStream(OPTIONS_FILE));
-        } catch (IOException ex) {
-            Logger.getLogger(GameOptions.class.getName()).log(Level.SEVERE, null, ex);
+    
+    private ArrayList<Boolean> generateDefaultAutoplayChannels() {
+        ArrayList<Boolean> out = new ArrayList<Boolean>();
+        for(Event.Channel c : Event.Channel.values())
+        {
+            if(c.toString().startsWith("NOTE_"))
+                out.add(c.isAutoplay());
         }
-        for (Property property : Property.values()) {
-            property.load(properties, this);
-        }
+        return out;
     }
     
-    public void save() {
-        Properties properties = new Properties();
-        for (Property property : Property.values()) {
-            property.save(properties, this);
-        }
-        try {
-            properties.store(new FileOutputStream(OPTIONS_FILE), "save the settings");
-        } catch (IOException ex) {
-            Logger.getLogger(GameOptions.class.getName()).log(Level.SEVERE, null, ex);
-        }
-    }
-
     /**
      * Gets the visibility modifier
      * @return the modifier
@@ -275,16 +114,16 @@ public class GameOptions {
      * Gets hi-speed value.
      * @return hi-speed
      */
-    public double getHiSpeed() {
-        return hispeed;
+    public double getSpeedMultiplier() {
+        return speedMultiplier;
     }
 
     /**
      * Sets hi-speed value.
      * @param new hi-speed value
      */
-    public void setHispeed(double hispeed) {
-        this.hispeed = hispeed;
+    public void setSpeedMultiplier(double hispeed) {
+        this.speedMultiplier = hispeed;
     }
 
     /**
@@ -292,7 +131,7 @@ public class GameOptions {
      * @return 
      */
     public SpeedType getSpeedType() {
-        return speed_type;
+        return speedType;
     }
 
     /**
@@ -300,7 +139,7 @@ public class GameOptions {
      * @param mod 
      */
     public void setSpeedType(SpeedType mod) {
-        this.speed_type = mod;
+        this.speedType = mod;
     }
 
     /**
@@ -340,7 +179,7 @@ public class GameOptions {
      * @return BGM volume
      */
     public float getBGMVolume() {
-        return BGMVolume;
+        return bgmVolume;
     }
 
     /**
@@ -348,7 +187,7 @@ public class GameOptions {
      * @param new BGM volume
      */
     public void setBGMVolume(float vol) {
-        BGMVolume = (float) clamp(vol, 0, 1);
+        bgmVolume = (float) clamp(vol, 0, 1);
     }
 
     /**
@@ -371,7 +210,7 @@ public class GameOptions {
      * Gets autoplay option value.
      * @return true if autoplay option is enabled, false otherwise
      */
-    public boolean getAutoplay() {
+    public boolean isAutoplay() {
         return autoplay;
     }
 
@@ -387,7 +226,7 @@ public class GameOptions {
      * Gets autosound option value.
      * @return true if autosound option is enabled, false otherwise
      */
-    public boolean getAutosound() {
+    public boolean isAutosound() {
         return autosound;
     }
 
@@ -399,51 +238,77 @@ public class GameOptions {
         this.autosound = autosound;
     }
     
-    public List<Boolean> getAutoplayChannels() {
-	return autoplay_channels;
-    }
-    
-    public void setAutoplayChannels(List<Boolean> list) {
-	this.autoplay_channels = (ArrayList<Boolean>) list;
-    }
-
-    public void setFullScreen(boolean fs) {
-        this.fullscreen = fs;
-    }
-
-    public boolean getFullScreen() {
-        return this.fullscreen;
-    }
-
-    public void setBilinear(boolean bi) {
-        this.bilinear = bi;
-    }
-
-    public boolean getBilinear() {
-        return bilinear;
-    }
-
-    public void setVsync(boolean vsync) {
-        this.vsync = vsync;
-    }
-
-    public boolean getVsync() {
-        return vsync;
-    }
-    
-    public void setVLC(String path) {
-	this.vlc = path;
-    }
-    
-    public String getVLC() {
-	return vlc;
-    }
-
     public void setDisplay(DisplayMode dm) {
-        this.width = dm.getWidth();
-        this.height = dm.getHeight();
-        this.bpp = dm.getBitsPerPixel();
-        this.freq = dm.getFrequency();
+        this.displayWidth = dm.getWidth();
+        this.displayHeight = dm.getHeight();
+        this.displayBitsPerPixel = dm.getBitsPerPixel();
+        this.displayFrequency = dm.getFrequency();
+    }
+    
+    public boolean isDisplaySaved(DisplayMode dm)
+    {
+        return dm.getWidth() == displayWidth && dm.getHeight() == displayHeight &&
+               dm.getBitsPerPixel() == displayBitsPerPixel && dm.getFrequency() == displayFrequency;
+    }
+    
+    private double clamp(double value, double min, double max) {
+        return Math.min(Math.max(value, min), max);
+    }
+
+    public double getAudioLatency() {
+        return audioLatency;
+    }
+
+    public void setAudioLatency(double audioLatency) {
+        this.audioLatency = audioLatency;
+    }
+
+    public ArrayList<Boolean> getAutoplayChannels() {
+        return autoplayChannels;
+    }
+
+    public void setAutoplayChannels(List<Boolean> autoplayChannels) {
+        this.autoplayChannels = new ArrayList<Boolean>(autoplayChannels);
+    }
+
+    public boolean isDisplayBilinear() {
+        return displayBilinear;
+    }
+
+    public void setDisplayBilinear(boolean displayBilinear) {
+        this.displayBilinear = displayBilinear;
+    }
+
+    public int getDisplayBitsPerPixel() {
+        return displayBitsPerPixel;
+    }
+
+    public void setDisplayBitsPerPixel(int displayBitsPerPixel) {
+        this.displayBitsPerPixel = displayBitsPerPixel;
+    }
+
+    public int getDisplayFrequency() {
+        return displayFrequency;
+    }
+
+    public void setDisplayFrequency(int displayFrequency) {
+        this.displayFrequency = displayFrequency;
+    }
+
+    public boolean isDisplayFullscreen() {
+        return displayFullscreen;
+    }
+
+    public void setDisplayFullscreen(boolean displayFullscreen) {
+        this.displayFullscreen = displayFullscreen;
+    }
+
+    public int getDisplayHeight() {
+        return displayHeight;
+    }
+
+    public void setDisplayHeight(int displayHeight) {
+        this.displayHeight = displayHeight;
     }
 
     public double getDisplayLag() {
@@ -454,21 +319,28 @@ public class GameOptions {
         this.displayLag = displayLag;
     }
 
-    public double getAudioLatency() {
-        return audioLatency;
+    public boolean isDisplayVsync() {
+        return displayVsync;
     }
 
-    public void setAudioLatency(double audioLatency) {
-        this.audioLatency = audioLatency;
+    public void setDisplayVsync(boolean displayVsync) {
+        this.displayVsync = displayVsync;
+    }
+
+    public int getDisplayWidth() {
+        return displayWidth;
+    }
+
+    public void setDisplayWidth(int displayWidth) {
+        this.displayWidth = displayWidth;
+    }
+
+    public String getVLCLibraryPath() {
+        return vlc;
+    }
+
+    public void setVLCLibraryPath(String vlc) {
+        this.vlc = vlc;
     }
     
-    public boolean isDisplaySaved(DisplayMode dm)
-    {
-        return dm.getWidth() == width && dm.getHeight() == height &&
-               dm.getBitsPerPixel() == bpp && dm.getFrequency() == freq;
-    }
-    
-    private double clamp(double value, double min, double max) {
-        return Math.min(Math.max(value, min), max);
-    }
 }

--- a/src/org/open2jam/gui/parts/Configuration.form
+++ b/src/org/open2jam/gui/parts/Configuration.form
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.1" encoding="UTF-8" ?>
 
 <Form version="1.5" maxVersion="1.7" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <AuxValues>
@@ -77,7 +77,7 @@
               <Group type="103" rootIndex="1" groupAlignment="0" attributes="0">
                   <Group type="102" alignment="0" attributes="0">
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="tKeys_scroll" pref="467" max="32767" attributes="0"/>
+                      <Component id="tKeys_scroll" pref="572" max="32767" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                   </Group>
               </Group>
@@ -97,7 +97,7 @@
                   <Group type="102" alignment="0" attributes="0">
                       <EmptySpace min="-2" pref="48" max="-2" attributes="0"/>
                       <Component id="tKeys_scroll" min="-2" pref="278" max="-2" attributes="0"/>
-                      <EmptySpace max="32767" attributes="0"/>
+                      <EmptySpace pref="23" max="32767" attributes="0"/>
                   </Group>
               </Group>
           </Group>

--- a/src/org/open2jam/gui/parts/Configuration.java
+++ b/src/org/open2jam/gui/parts/Configuration.java
@@ -54,7 +54,7 @@ public class Configuration extends javax.swing.JPanel {
         
         loadTableKeys(Config.KeyboardType.K7);
 	
-	vlc_path = Config.getGameOptions().getVLC();
+	vlc_path = Config.getGameOptions().getVLCLibraryPath();
 	if(vlc_path.isEmpty()) {
 	    lbl_vlc.setText("Select the VLC path");
 	} else {
@@ -212,7 +212,7 @@ public class Configuration extends javax.swing.JPanel {
         }
         Config.setKeyboardMap(kb_map, kt);
 	GameOptions op = Config.getGameOptions();
-	op.setVLC(vlc_path);
+	op.setVLCLibraryPath(vlc_path);
 	Config.setGameOptions(op);
 }//GEN-LAST:event_bSaveActionPerformed
 

--- a/src/org/open2jam/gui/parts/MusicSelection.java
+++ b/src/org/open2jam/gui/parts/MusicSelection.java
@@ -221,14 +221,14 @@ public class MusicSelection extends javax.swing.JPanel
         // TODO: read Config gameOptions and set them on the GUI
         GameOptions go = Config.getGameOptions();
         
-        jc_autoplay.setSelected(go.getAutoplay());
-	jc_autosound.setSelected(go.getAutosound());
+        jc_autoplay.setSelected(go.isAutoplay());
+	jc_autosound.setSelected(go.isAutosound());
         combo_channelModifier.setSelectedItem(go.getChannelModifier());
         combo_visibilityModifier.setSelectedItem(go.getVisibilityModifier());
         slider_main_vol.setValue(Math.round(go.getMasterVolume()*100));
         slider_key_vol.setValue(Math.round(go.getKeyVolume()*100));
         slider_bgm_vol.setValue(Math.round(go.getBGMVolume()*100));
-        js_hispeed.setValue(go.getHiSpeed());
+        js_hispeed.setValue(go.getSpeedMultiplier());
         combo_speedType.setSelectedItem(go.getSpeedType());
         txt_displayLag.setText(go.getDisplayLag() + "");
         txt_audioLatency.setText(go.getAudioLatency() + "");
@@ -239,9 +239,9 @@ public class MusicSelection extends javax.swing.JPanel
                 combo_displays.setSelectedItem(dm);
         }
 
-        jc_full_screen.setSelected(go.getFullScreen());
-        jc_bilinear.setSelected(go.getBilinear());
-        jc_vsync.setSelected(go.getVsync());
+        jc_full_screen.setSelected(go.isDisplayFullscreen());
+        jc_bilinear.setSelected(go.isDisplayBilinear());
+        jc_vsync.setSelected(go.isDisplayVsync());
         
     }
     
@@ -259,11 +259,11 @@ public class MusicSelection extends javax.swing.JPanel
         go.setMasterVolume(slider_main_vol.getValue()/100f);
         go.setKeyVolume(slider_key_vol.getValue()/100f);
         go.setBGMVolume(slider_bgm_vol.getValue()/100f);
-        go.setHispeed((Double)js_hispeed.getValue());
+        go.setSpeedMultiplier((Double)js_hispeed.getValue());
         go.setSpeedType((SpeedType)combo_speedType.getSelectedItem());
-        go.setFullScreen(jc_full_screen.isSelected());
-        go.setBilinear(jc_bilinear.isSelected());
-        go.setVsync(jc_vsync.isSelected());
+        go.setDisplayFullscreen(jc_full_screen.isSelected());
+        go.setDisplayBilinear(jc_bilinear.isSelected());
+        go.setDisplayVsync(jc_vsync.isSelected());
         
         go.setDisplay((DisplayMode)combo_displays.getSelectedItem());
         
@@ -1052,11 +1052,11 @@ public class MusicSelection extends javax.swing.JPanel
             go.setMasterVolume(mainVol);
             go.setKeyVolume(keyVol);
             go.setBGMVolume(bgmVol);
-            go.setHispeed(hispeed);
+            go.setSpeedMultiplier(hispeed);
             go.setSpeedType(speed_type);
-            go.setFullScreen(fs);
-            go.setBilinear(bilinear);
-            go.setVsync(vsync);
+            go.setDisplayFullscreen(fs);
+            go.setDisplayBilinear(bilinear);
+            go.setDisplayVsync(vsync);
             
             try{
                 go.setDisplayLag(Double.parseDouble(txt_displayLag.getText()));
@@ -1072,7 +1072,7 @@ public class MusicSelection extends javax.swing.JPanel
                 return;
             }
 
-            NativeLibrary.addSearchPath("vlc", go.getVLC());
+            NativeLibrary.addSearchPath("vlc", go.getVLCLibraryPath());
             
             final Render r;
             r = new Render(selected_header, go, dm);

--- a/src/org/open2jam/render/Render.java
+++ b/src/org/open2jam/render/Render.java
@@ -245,7 +245,7 @@ public class Render implements GameWindowCallback
         this.chart = chart;
         this.opt = opt;
 
-        this.next_speed = this.last_speed = speed = opt.getHiSpeed();
+        this.next_speed = this.last_speed = speed = opt.getSpeedMultiplier();
         switch(opt.getSpeedType())
         {
             case xRSpeed:
@@ -259,10 +259,10 @@ public class Render implements GameWindowCallback
             break;
         }
 	
-	AUTOSOUND = opt.getAutosound();
+	AUTOSOUND = opt.isAutosound();
 	
 	//TODO Should get values from gameoptions, but i'm lazy as hell
-	if(opt.getAutoplay()) 
+	if(opt.isAutoplay()) 
 	{
 	    for(Event.Channel c : Event.Channel.values())
 	    {
@@ -277,7 +277,7 @@ public class Render implements GameWindowCallback
         displayLatency = new Latency(opt.getDisplayLag());
         audioLatency = new Latency(opt.getAudioLatency());
 	
-        window.setDisplay(dm,opt.getVsync(),opt.getFullScreen(),opt.getBilinear());
+        window.setDisplay(dm,opt.isDisplayVsync(),opt.isDisplayFullscreen(),opt.isDisplayBilinear());
     }
 
     public void setAutosyncDelegate(AutosyncDelegate autosyncDelegate) {


### PR DESCRIPTION
I found a class, "XMLEncoder" which encodes a JavaBean into XML file.

I think that this is less messy than the current "properties" implementation...

The commits in this branch removes all the manual serialization of GameOptions and back (GameOptions <-> Properties), and uses XMLEncoder and XMLDecoder instead.

In addition, the GameOptions class no longer contains the logic for loading and saving game options to file system. It is now the responsibility of the Config class to do it. The GameOptions class now only contains the options.

Also note that the configuration file name is changed to "game-options.xml" instead of "game_options.properties".
