### PR TITLE
fixes

### DIFF
--- a/parsers/src/org/open2jam/parsers/utils/ByteHelper.java
+++ b/parsers/src/org/open2jam/parsers/utils/ByteHelper.java
@@ -47,7 +47,7 @@ public class ByteHelper {
 	    (byte) (i),
 	    (byte) (i >> 8),
 	    (byte) (i >> 16),
-	    (byte) (i >> 24)
+	    (byte) (i >>> 24)
 	};
     }
     

--- a/parsers/src/org/open2jam/parsers/utils/SampleData.java
+++ b/parsers/src/org/open2jam/parsers/utils/SampleData.java
@@ -50,6 +50,9 @@ public class SampleData {
     }
     
     public void copyTo(OutputStream out) throws IOException {
+        if(this.type == Type.WAV_NO_HEADER) {
+            out.write(WAVHeader.writeHeader(this.wavHeader));
+        }
 	ByteHelper.copyTo(this.input, out);
     }
     

--- a/src/org/open2jam/render/Render.java
+++ b/src/org/open2jam/render/Render.java
@@ -962,7 +962,7 @@ public class Render implements GameWindowCallback
         note_counter.get(result).incNumber();
         
         // for cool: display the effect
-        if (result == JudgmentResult.COOL) {
+        if (result == JudgmentResult.COOL || result == JudgmentResult.GOOD) {
             Entity ee = skin.getEntityMap().get("EFFECT_CLICK").copy();
             ee.setPos(ne.getX()+ne.getWidth()/2-ee.getWidth()/2,
             getViewport()-ee.getHeight()/2);


### PR DESCRIPTION
Looks like pure wave samples were missing the header on the copyTo, that means fmod ended up dieing with a error message.
These pure wave samples are found on OMC-type OJM files.

2nd commit, just adding the hit effect for GOOD's too because thats how o2jam does it.
