### PR TITLE
More fine-grained sound control

### DIFF
--- a/src/org/open2jam/render/entities/NoteEntity.java
+++ b/src/org/open2jam/render/entities/NoteEntity.java
@@ -46,10 +46,16 @@ public class NoteEntity extends AnimatedEntity implements TimeEntity
         return sampleEntity;
     }
     
+    /**
+     * Triggers the note's keysound. Must be from user event.
+     */
     public void keysound() {
         if (sampleEntity != null) sampleEntity.keysound();
     }
     
+    /**
+     * Stops the note's keysound.
+     */
     public void missed() {
         if (sampleEntity != null) sampleEntity.missed();
     }

--- a/src/org/open2jam/render/entities/NoteEntity.java
+++ b/src/org/open2jam/render/entities/NoteEntity.java
@@ -46,8 +46,12 @@ public class NoteEntity extends AnimatedEntity implements TimeEntity
         return sampleEntity;
     }
     
-    public void emitSound() {
-        if (sampleEntity != null) sampleEntity.judgment(false);
+    public void keysound() {
+        if (sampleEntity != null) sampleEntity.keysound();
+    }
+    
+    public void missed() {
+        if (sampleEntity != null) sampleEntity.missed();
     }
 
     public void setHitTime(double hit) { this.hitTime = hit; }

--- a/src/org/open2jam/render/entities/SampleEntity.java
+++ b/src/org/open2jam/render/entities/SampleEntity.java
@@ -40,6 +40,10 @@ public class SampleEntity extends Entity implements TimeEntity, SoundEntity
         this.render = org.render;
     }
 
+    /**
+     * Sets the "belongs to a note" flag.
+     * @param note true if this SampleEntity belongs to a note, false otherwise.
+     */
     public void setNote(boolean note) {
         this.note = note;
     }
@@ -52,6 +56,10 @@ public class SampleEntity extends Entity implements TimeEntity, SoundEntity
         autosound();
     }
     
+    /**
+     * Invoked when the sound is played automatically (either by autosound or
+     * that the note is an autokeysound).
+     */
     public void autosound() {
         if (!note || !render.isDisableAutoSound()) {
             keysound();
@@ -59,6 +67,10 @@ public class SampleEntity extends Entity implements TimeEntity, SoundEntity
         setDead(true);
     }
     
+    /**
+     * Invoked when the sound is triggered by the player when it's time to hit
+     * the note.
+     */
     public void keysound() {
         if (!played) {
             played = true;
@@ -66,10 +78,17 @@ public class SampleEntity extends Entity implements TimeEntity, SoundEntity
         }
     }
     
+    /**
+     * Invoked when the sound is triggered by the player when it's not the time
+     * to hit the note.
+     */
     public void extrasound() {
         play();
     }
     
+    /**
+     * Invoked when the note was missed and the sound should stop.
+     */
     public void missed() {
         if (instance == null) return;
         instance.stop();

--- a/src/org/open2jam/render/entities/SampleEntity.java
+++ b/src/org/open2jam/render/entities/SampleEntity.java
@@ -8,6 +8,7 @@ package org.open2jam.render.entities;
 import org.open2jam.parsers.Event;
 import org.open2jam.parsers.Event.SoundSample;
 import org.open2jam.render.Render;
+import org.open2jam.sound.SoundInstance;
 
 /**
  *
@@ -21,6 +22,7 @@ public class SampleEntity extends Entity implements TimeEntity, SoundEntity
     private double time_to_hit;
     private boolean note = false;
     private boolean played = false;
+    private SoundInstance instance;
     
     public SampleEntity(Render r, Event.SoundSample value, double y)
     {
@@ -47,26 +49,31 @@ public class SampleEntity extends Entity implements TimeEntity, SoundEntity
 
     @Override
     public void judgment() {
-        judgment(true);
+        autosound();
     }
     
-    public void judgment(boolean auto)
-    {
-        boolean play = !auto;
-        if (!dead && (!note || !render.isDisableAutoSound())) {
-            play = true;
-        }
-        if (play && !played) {
-            this.play();
+    public void autosound() {
+        if (!render.isDisableAutoSound()) keysound();
+    }
+    
+    public void keysound() {
+        if (!played) {
             played = true;
-        }
-        if (!dead) {
-            dead = true;
+            instance = play();
         }
     }
-
-    public void play() {
-        render.queueSample(value);
+    
+    public void extrasound() {
+        play();
+    }
+    
+    public void missed() {
+        if (instance == null) return;
+        instance.stop();
+    }
+    
+    private SoundInstance play() {
+        return render.queueSample(value);
     }
     
     @Override

--- a/src/org/open2jam/render/entities/SampleEntity.java
+++ b/src/org/open2jam/render/entities/SampleEntity.java
@@ -53,7 +53,10 @@ public class SampleEntity extends Entity implements TimeEntity, SoundEntity
     }
     
     public void autosound() {
-        if (!render.isDisableAutoSound()) keysound();
+        if (!note || !render.isDisableAutoSound()) {
+            keysound();
+        }
+        setDead(true);
     }
     
     public void keysound() {

--- a/src/org/open2jam/sound/FmodExSoundSystem.java
+++ b/src/org/open2jam/sound/FmodExSoundSystem.java
@@ -128,7 +128,8 @@ public class FmodExSoundSystem implements SoundSystem {
             errorCheck(system.createSound(buffer, FMOD_MODE.FMOD_SOFTWARE | FMOD_MODE.FMOD_OPENMEMORY, exinfo, sound));
         }
         
-        public void play(SoundChannel soundChannel, float volume, float pan) throws SoundSystemException {
+        @Override
+        public SoundInstance play(SoundChannel soundChannel, float volume, float pan) throws SoundSystemException {
             Channel channel = new Channel();
             errorCheck(system.playSound(FMOD_CHANNELINDEX.FMOD_CHANNEL_FREE, sound, true, channel));
             errorCheck(channel.setVolume(Math.min(1, volume)));
@@ -137,6 +138,22 @@ public class FmodExSoundSystem implements SoundSystem {
             errorCheck(channel.setLoopCount(0));
             errorCheck(channel.setChannelGroup(soundChannel == SoundChannel.BGM ? bgmGroup : keyGroup));
             system.update();
+            if (channel.isNull()) return null;
+            return new FmodSoundInstance(channel);
+        }
+        
+    }
+    
+    class FmodSoundInstance implements SoundInstance {
+        private final Channel channel;
+
+        private FmodSoundInstance(Channel channel) {
+            this.channel = channel;
+        }
+
+        @Override
+        public void stop() {
+            channel.stop();
         }
         
     }

--- a/src/org/open2jam/sound/Sound.java
+++ b/src/org/open2jam/sound/Sound.java
@@ -10,6 +10,6 @@ package org.open2jam.sound;
  */
 public interface Sound {
     
-    void play(SoundChannel soundChannel, float volume, float pan) throws SoundSystemException;
+    SoundInstance play(SoundChannel soundChannel, float volume, float pan) throws SoundSystemException;
     
 }

--- a/src/org/open2jam/sound/SoundInstance.java
+++ b/src/org/open2jam/sound/SoundInstance.java
@@ -1,0 +1,11 @@
+package org.open2jam.sound;
+
+/**
+ *
+ * @author Thai Pangsakulyanont
+ */
+public interface SoundInstance {
+    
+    void stop();
+    
+}


### PR DESCRIPTION
The play() method in Sound interface will now return a SoundInstance object which can be used to control that particular instance of a played sound

For now we have the stop() methods that stops the sound instance.

When the player missed the note that whose keysound is autoplayed by autosound, the autoplayed keysound will stop.

The sound also stops when the player released a long note before the note's tail, so it's more like newer games. If that isn't a good idea, then it can be disabled easily, but now we have more control over sound instances.
