### PR TITLE
Remove Type Parameter from combo_dirs

### DIFF
--- a/src/org/open2jam/gui/parts/MusicSelection.form
+++ b/src/org/open2jam/gui/parts/MusicSelection.form
@@ -213,7 +213,7 @@
             <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="combo_dirsItemStateChanged"/>
           </Events>
           <AuxValues>
-            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;FileItem&gt;"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value=""/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JButton" name="btn_reload">

--- a/src/org/open2jam/gui/parts/MusicSelection.java
+++ b/src/org/open2jam/gui/parts/MusicSelection.java
@@ -293,7 +293,7 @@ public class MusicSelection extends javax.swing.JPanel
         bt_choose_dir = new javax.swing.JButton();
         load_progress = new javax.swing.JProgressBar();
         jLabel2 = new javax.swing.JLabel();
-        combo_dirs = new javax.swing.JComboBox<FileItem>();
+        combo_dirs = new javax.swing.JComboBox();
         btn_reload = new javax.swing.JButton();
         btn_delete = new javax.swing.JButton();
         panel_setting = new javax.swing.JPanel();
@@ -574,7 +574,7 @@ public class MusicSelection extends javax.swing.JPanel
                     .addComponent(btn_delete)
                     .addComponent(load_progress, javax.swing.GroupLayout.PREFERRED_SIZE, 27, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(table_scroll, javax.swing.GroupLayout.DEFAULT_SIZE, 338, Short.MAX_VALUE)
+                .addComponent(table_scroll, javax.swing.GroupLayout.DEFAULT_SIZE, 334, Short.MAX_VALUE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(panel_listLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(txt_filter, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -854,7 +854,7 @@ public class MusicSelection extends javax.swing.JPanel
         );
         panel_infoLayout.setVerticalGroup(
             panel_infoLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 356, Short.MAX_VALUE)
+            .addGap(0, 352, Short.MAX_VALUE)
             .addGroup(panel_infoLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                 .addGroup(panel_infoLayout.createSequentialGroup()
                     .addContainerGap()
@@ -891,7 +891,7 @@ public class MusicSelection extends javax.swing.JPanel
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                     .addComponent(lbl_artist)
                     .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                    .addComponent(table_scroll2, javax.swing.GroupLayout.DEFAULT_SIZE, 73, Short.MAX_VALUE)
+                    .addComponent(table_scroll2, javax.swing.GroupLayout.DEFAULT_SIZE, 69, Short.MAX_VALUE)
                     .addContainerGap()))
         );
 
@@ -1285,7 +1285,7 @@ public class MusicSelection extends javax.swing.JPanel
     private javax.swing.JCheckBox cb_autoSyncDisplay;
     private javax.swing.JCheckBox cb_startPaused;
     private javax.swing.JComboBox combo_channelModifier;
-    private javax.swing.JComboBox<FileItem> combo_dirs;
+    private javax.swing.JComboBox combo_dirs;
     private javax.swing.JComboBox combo_displays;
     private javax.swing.JComboBox combo_speedType;
     private javax.swing.JComboBox combo_visibilityModifier;


### PR DESCRIPTION
Java 1.6 is required for the game to work on a Mac (LWJGL doesn't work with Oracle's Java 1.7), and in Java 1.6, JComboBox could not accept type parameters.

So for now, I think it's best to just remove the type parameters (or additionally add some @SuppressWarning annotation...).
