### PR TITLE
Fix various crashes in game...

### DIFF
--- a/src/org/open2jam/gui/parts/MusicSelection.java
+++ b/src/org/open2jam/gui/parts/MusicSelection.java
@@ -1480,10 +1480,15 @@ public class MusicSelection extends javax.swing.JPanel
     public void valueChanged(ListSelectionEvent e) {
         int i = table_songlist.getSelectedRow();
         if(i < 0 && last_model_idx >= 0){
-            i = last_model_idx;
-            int i_view = table_songlist.convertRowIndexToView(i);
-            table_songlist.getSelectionModel().setSelectionInterval(0, i_view);
-            table_scroll.getVerticalScrollBar().setValue(table_songlist.getCellRect(i_view, 0, false).y);
+            try {
+                i = last_model_idx;
+                int i_view = table_songlist.convertRowIndexToView(i);
+                table_songlist.getSelectionModel().setSelectionInterval(0, i_view);
+                table_scroll.getVerticalScrollBar().setValue(table_songlist.getCellRect(i_view, 0, false).y);
+            } catch (IndexOutOfBoundsException up) {
+                table_songlist.getSelectionModel().setSelectionInterval(0, -1);
+                // not sure what to do with it here...
+            }
         }else{
             i = table_songlist.convertRowIndexToModel(i);
         }

--- a/src/org/open2jam/render/Render.java
+++ b/src/org/open2jam/render/Render.java
@@ -829,10 +829,15 @@ public class Render implements GameWindowCallback
                 if (!gameStarted && localMatching == null) gameStarted = true;  
                 
                 keyboard_key_pressed.put(c, true);
-
-                Entity ee = skin.getEntityMap().get("PRESSED_"+c).copy();
-                entities_matrix.add(ee);
-                Entity to_kill = key_pressed_entity.put(c, ee);
+                Entity baseEntity = skin.getEntityMap().get("PRESSED_"+c);
+                Entity to_kill = null;
+                
+                if (baseEntity != null) {
+                    Entity ee = baseEntity.copy();
+                    entities_matrix.add(ee);
+                    to_kill = key_pressed_entity.put(c, ee);
+                }
+                
                 if(to_kill != null)to_kill.setDead(true);
 
                 NoteEntity e = nextNoteKey(c);
@@ -862,7 +867,9 @@ public class Render implements GameWindowCallback
             }else if(!keyDown && keyWasDown) { // key released now
 
                 keyboard_key_pressed.put(c, false);
-                key_pressed_entity.get(c).setDead(true);
+                Entity to_kill = key_pressed_entity.get(c);
+                
+                if(to_kill != null)to_kill.setDead(true);
 
                 Entity lf = longflare.remove(c);
                 if(lf !=null)lf.setDead(true);


### PR DESCRIPTION
- Sometimes when changing directory, the music selection GUI crashes. This <del>patch</del> <ins>hack</ins> prevents it.

Here is the original error message that occured:

```
Exception in thread "AWT-EventQueue-0"
java.lang.IndexOutOfBoundsException: Invalid index
    at
javax.swing.DefaultRowSorter.convertRowIndexToView(DefaultRowSorter.java
:482)
    at javax.swing.JTable.convertRowIndexToView(JTable.java:2589)
    at
org.open2jam.gui.parts.MusicSelection.valueChanged(MusicSelection.java:1
484)
    at
javax.swing.DefaultListSelectionModel.fireValueChanged(DefaultListSelect
ionModel.java:167)
```
- Pressing the shift key (scratch) crashes the game. This patch also fixes it.
