### PR TITLE
Open a LWJGL window in a separate thread when assigning keys

### DIFF
--- a/src/org/open2jam/gui/Interface.java
+++ b/src/org/open2jam/gui/Interface.java
@@ -26,7 +26,7 @@ public class Interface extends javax.swing.JFrame implements WindowListener
         musicSelection = new MusicSelection();
         
         Tabs.addTab("Music Selection", musicSelection);
-        Tabs.addTab("Configuration", new Configuration(this));
+        Tabs.addTab("Configuration", new Configuration());
         
         this.addWindowListener(this);
 	pack();

--- a/src/org/open2jam/gui/Interface.java
+++ b/src/org/open2jam/gui/Interface.java
@@ -26,7 +26,7 @@ public class Interface extends javax.swing.JFrame implements WindowListener
         musicSelection = new MusicSelection();
         
         Tabs.addTab("Music Selection", musicSelection);
-        Tabs.addTab("Configuration", new Configuration());
+        Tabs.addTab("Configuration", new Configuration(this));
         
         this.addWindowListener(this);
 	pack();

--- a/src/org/open2jam/gui/parts/Configuration.java
+++ b/src/org/open2jam/gui/parts/Configuration.java
@@ -217,21 +217,27 @@ public class Configuration extends javax.swing.JPanel {
 }//GEN-LAST:event_bSaveActionPerformed
 
     private void tKeysMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_tKeysMouseClicked
-        int row = tKeys.getSelectedRow();
+        final int row = tKeys.getSelectedRow();
         if(tKeys.getValueAt(row, 0) == null) return;
-        
-        int code;
-        int lastkey = Keyboard.getKeyIndex(tKeys.getValueAt(row, 1).toString());
-        try {
-            code = read_keyboard_key(lastkey);
-        } catch(LWJGLException e) {
-            // FML
-            return;
-        }
-        if(kb_map.containsValue(code)) return; //check for duplicates, TODO something informing about the duplicate
-        Event.Channel c = table_map.get(row);
-        kb_map.put(c, code);
-        tKeys.setValueAt(Keyboard.getKeyName(code), row, 1);
+        new Thread() {
+
+            @Override
+            public void run() {
+                int lastkey = Keyboard.getKeyIndex(tKeys.getValueAt(row, 1).toString());
+                int code;
+                try {
+                    code = read_keyboard_key(lastkey);
+                } catch(LWJGLException e) {
+                    // FML
+                    return;
+                }
+                if(kb_map.containsValue(code)) return; //check for duplicates, TODO something informing about the duplicate
+                Event.Channel c = table_map.get(row);
+                kb_map.put(c, code);
+                tKeys.setValueAt(Keyboard.getKeyName(code), row, 1);
+            }
+            
+        }.start();
 }//GEN-LAST:event_tKeysMouseClicked
 
     private void combo_keyboardConfigActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_combo_keyboardConfigActionPerformed

--- a/src/org/open2jam/gui/parts/Configuration.java
+++ b/src/org/open2jam/gui/parts/Configuration.java
@@ -6,6 +6,8 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.table.DefaultTableModel;
 import org.lwjgl.LWJGLException;
@@ -15,6 +17,7 @@ import org.lwjgl.opengl.DisplayMode;
 import org.lwjgl.opengl.GL11;
 import org.open2jam.Config;
 import org.open2jam.GameOptions;
+import org.open2jam.gui.Interface;
 import org.open2jam.parsers.Event;
 import org.open2jam.render.lwjgl.TrueTypeFont;
 
@@ -47,9 +50,10 @@ public class Configuration extends javax.swing.JPanel {
 	    return "libvlc file";
 	}
     };
+    private final JFrame frame;
     
     /** Creates new form Configuration */
-    public Configuration() {
+    public Configuration(JFrame frame) {
         initComponents();
         
         loadTableKeys(Config.KeyboardType.K7);
@@ -60,8 +64,10 @@ public class Configuration extends javax.swing.JPanel {
 	} else {
 	    lbl_vlc.setText("VLC Path: "+vlc_path);
 	}
+        this.frame = frame;
 
     }
+
 
     /** This method is called from within the constructor to
      * initialize the form.
@@ -219,16 +225,25 @@ public class Configuration extends javax.swing.JPanel {
     private void tKeysMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_tKeysMouseClicked
         final int row = tKeys.getSelectedRow();
         if(tKeys.getValueAt(row, 0) == null) return;
+        frame.setEnabled(false);
         new Thread() {
 
             @Override
             public void run() {
+                work();
+                SwingUtilities.invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        frame.setEnabled(true);
+                    }
+                });
+            }
+            private void work() {
                 int lastkey = Keyboard.getKeyIndex(tKeys.getValueAt(row, 1).toString());
                 int code;
                 try {
                     code = read_keyboard_key(lastkey);
                 } catch(LWJGLException e) {
-                    // FML
                     return;
                 }
                 if(kb_map.containsValue(code)) return; //check for duplicates, TODO something informing about the duplicate

--- a/src/org/open2jam/gui/parts/Configuration.java
+++ b/src/org/open2jam/gui/parts/Configuration.java
@@ -50,10 +50,9 @@ public class Configuration extends javax.swing.JPanel {
 	    return "libvlc file";
 	}
     };
-    private final JFrame frame;
     
     /** Creates new form Configuration */
-    public Configuration(JFrame frame) {
+    public Configuration() {
         initComponents();
         
         loadTableKeys(Config.KeyboardType.K7);
@@ -64,8 +63,6 @@ public class Configuration extends javax.swing.JPanel {
 	} else {
 	    lbl_vlc.setText("VLC Path: "+vlc_path);
 	}
-        this.frame = frame;
-
     }
 
 
@@ -225,7 +222,7 @@ public class Configuration extends javax.swing.JPanel {
     private void tKeysMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_tKeysMouseClicked
         final int row = tKeys.getSelectedRow();
         if(tKeys.getValueAt(row, 0) == null) return;
-        frame.setEnabled(false);
+        getTopLevelAncestor().setEnabled(false);
         new Thread() {
 
             @Override
@@ -234,7 +231,7 @@ public class Configuration extends javax.swing.JPanel {
                 SwingUtilities.invokeLater(new Runnable() {
                     @Override
                     public void run() {
-                        frame.setEnabled(true);
+                        getTopLevelAncestor().setEnabled(true);
                     }
                 });
             }


### PR DESCRIPTION
On Mac OS X, in configuration screen, the game crashes when I try to change the keyboard bindings, so I created a new thread for the LWJGL window and that fixed it.

@chaosfox, @mrcdk, could you check if it still works on Windows/Linux or not?
